### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+  
+workflows:
+  version: 2
+  CICD:
+    jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: team-commet

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+# add false positives here

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.16.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds [Secrets Scanning](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/1563787412/Secrets+Scanning) to the repository. @snyk/comet please review the secrets in .gitleakesignore and verify that none of them is still active. See [How to Handle Secrets in Git History](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/1563787412/Secrets+Scanning#4.2.-Handling-Initial-Scan-Results).